### PR TITLE
add endpoint_image option to clab-topo API

### DIFF
--- a/ansible-eda/rulebook.yaml
+++ b/ansible-eda/rulebook.yaml
@@ -16,6 +16,7 @@
           extra_vars:
             network_name: "{{ event.payload.network_name }}"
             crpd_image: "{{ event.payload.crpd_image }}"
+            endpoint_image: "{{ event.payload.endpoint_image }}"
             snapshot_name: "{{ event.payload.snapshot_name }}"
             usecase_name: "{{ event.payload.usecase_name }}"
             with_clab: "true"
@@ -33,7 +34,7 @@
             with_clab: "true"
             iperf_commands: "{{ event.payload.iperf_commands}}"
             remote_address: "{{ event.payload.remote_address }}"
-    - name: clab destory
+    - name: clab destroy
       condition: event.payload.message == "destroy"
       action:
         run_playbook:
@@ -41,6 +42,7 @@
           extra_vars:
             network_name: "{{ event.payload.network_name }}"
             crpd_image: "{{ event.payload.crpd_image }}"
+            endpoint_image: "{{ event.payload.endpoint_image }}"
             snapshot_name: "{{ event.payload.snapshot_name }}"
             usecase_name: "{{ event.payload.usecase_name }}"
             with_clab: "true"
@@ -50,4 +52,4 @@
       action:
         shutdown:
           delay: 15
-          message: "Shutting down"       
+          message: "Shutting down"

--- a/playbooks/containerlab.yaml
+++ b/playbooks/containerlab.yaml
@@ -18,7 +18,7 @@
 
     - name: delete iperf file
       shell: rm -f /clab/iperf_params.json
- 
+
     - shell: 'echo "job_status{jobname=\"Preparing_Deploy_Clab\",network_name=\"{{ network_name }}\",snapshot_name=\"{{ snapshot_name }}\"} 1" > /prom/textfile.prom'
     - name: "get convert table"
       uri:
@@ -26,7 +26,7 @@
         method: "GET"
         body_format: json
       register: layer3_convert_table
-    
+
     - name: download generated config
       shell: "curl {{ url }}/{{ item.agent_name }}.conf | jq -r .text > {{ filepath }}"
       vars:
@@ -43,7 +43,7 @@
 
     - name: "get clab topo yaml"
       uri:
-        url: "http://{{ conductor_address }}/topologies/{{ network_name }}/{{ snapshot_name }}/topology/layer3/containerlab_topology?image={{ crpd_image }}&bind_license=license.key:/tmp/license.key:ro"
+        url: "http://{{ conductor_address }}/topologies/{{ network_name }}/{{ snapshot_name }}/topology/layer3/containerlab_topology?image={{ crpd_image }}&bind_license=license.key:/tmp/license.key:ro&endpoint_image={{ endpoint_image }}"
         method: "GET"
         body_format: json
       register: containerlab
@@ -80,7 +80,7 @@
 
     - name: Pause for 30 sec to build app cache
       ansible.builtin.pause:
-        seconds: 30        
+        seconds: 30
 
     - name: enable bgp license
       shell:

--- a/playbooks/destroy.yaml
+++ b/playbooks/destroy.yaml
@@ -14,7 +14,7 @@
 
     - name: "get clab topo yaml"
       uri:
-        url: "http://{{ conductor_address }}/topologies/{{ network_name }}/{{ snapshot_name }}/topology/layer3/containerlab_topology?image={{ crpd_image }}&bind_license=license.key:/tmp/license.key:ro"
+        url: "http://{{ conductor_address }}/topologies/{{ network_name }}/{{ snapshot_name }}/topology/layer3/containerlab_topology?image={{ crpd_image }}&bind_license=license.key:/tmp/license.key:ro&endpoint_image={{ endpoint_image }}"
         method: "GET"
         body_format: json
       register: containerlab


### PR DESCRIPTION
clab-topo生成時にiperf endpointのコンテナイメージ/タグをコントローラスクリプトから指定できるように変更